### PR TITLE
Add support for exporting more PyTorch modules in weight_convert.py

### DIFF
--- a/module_as_dict.py
+++ b/module_as_dict.py
@@ -1,0 +1,141 @@
+import torch
+import torch.nn as nn
+
+def module_to_dict(module):
+    """
+    Converts PyTorch module to dictionary of parameters.
+
+    Args:
+        module (nn.Module): The module to be converted
+
+    Returns:
+        Dict[str, object]: Dictionary of module's parameters, where the name of the parameter is the `str` and the `object` is the parameter's value. Returns None if module is unsupported.
+    """
+
+    # Convolutions
+    if isinstance(module, nn.Conv1d):
+        return {
+            'name': module.__class__.__name__,
+            'in_channels': module.in_channels,
+            'out_channels': module.out_channels,
+            'kernel_size': module.kernel_size,
+            'stride': module.stride,
+            'padding': module.padding,
+        }
+    elif isinstance(module, nn.Conv2d):
+        return {
+            'name': module.__class__.__name__,
+            'in_channels': module.in_channels,
+            'out_channels': module.out_channels,
+            'kernel_size': module.kernel_size,
+            'stride': module.stride,
+            'padding': module.padding,
+        }
+
+    # Pooling
+    elif isinstance(module, nn.MaxPool1d):
+        return {
+            'name': module.__class__.__name__,
+            'kernel_size': module.kernel_size,
+            'stride': module.stride,
+            'padding': module.padding,
+            'dilation': module.dilation,
+        }
+    elif isinstance(module, nn.MaxPool2d):
+        return {
+            'name': module.__class__.__name__,
+            'kernel_size': module.kernel_size,
+            'stride': module.stride,
+            'padding': module.padding,
+            'dilation': module.dilation,
+        }
+    elif isinstance(module, nn.AvgPool1d):
+        return {
+            'name': module.__class__.__name__,
+            'kernel_size': kernel_size,
+            'stride': module.stride,
+            'padding': module.padding,
+        }
+    elif isinstance(module, nn.AvgPool2d):
+        return {
+            'name': module.__class__.__name__,
+            'kernel_size': kernel_size,
+            'stride': module.stride,
+            'padding': module.padding,
+        }
+
+    # Normalization
+    elif isinstance(module, nn.BatchNorm1d):
+        return {
+            'name': module.__class__.__name__,
+            'num_features': module.num_features,
+        }
+    elif isinstance(module, nn.BatchNorm2d):
+        return {
+            'name': module.__class__.__name__,
+            'num_features': module.num_features,
+        }
+    elif isinstance(module, nn.LayerNorm):
+        return {
+            'name': module.__class__.__name__,
+            'normalized_shape': module.normalized_shape,
+        }
+
+    # Activation layers
+    elif isinstance(module, nn.ReLU):
+        return {
+            'name': module.__class_.__name__,
+        }
+    elif isinstance(module, nn.LeakyReLU):
+        return {
+            'name': module.__class_.__name__,
+            'negative_slope': negative_slope,
+        }
+    elif isinstance(module, nn.Sigmoid):
+        return {
+            'name': module.__class_.__name__,
+        }
+    elif isinstance(module, nn.Tanh):
+        return {
+            'name': module.__class_.__name__,
+        }
+    elif isinstance(module, nn.Softmax):
+        return {
+            'name': module.__class_.__name__,
+            'dim': module.dim
+        }
+    elif isinstance(module, nn.LogSoftmax):
+        return {
+            'name': module.__class_.__name__,
+            'dim': module.dim
+        }
+
+    # Linear
+    elif isinstance(module, nn.Linear):
+        return {
+            'name': module.__class__.__name__,
+            'in_features': module.in_features,
+            'out_features': module.out_features,
+            'bias': module.bias,
+        }
+    elif isinstance(module, nn.Identity):
+        return {
+            'name': module.__class__.__name__,
+        }
+
+    # Dropout
+    elif isinstance(module, nn.Dropout):
+        return {
+            'name': module.__class__.__name__,
+            'p': module.p,
+        }
+
+    # Loss
+    elif isinstance(module, nn.CrossEntropyLoss):
+        return {
+            'name': module.__class__.__name__,
+        }
+
+    else:
+        return None
+

--- a/weight_convert.py
+++ b/weight_convert.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 import numpy as np
 
 from models import get_model_arch
+from module_as_dict import module_to_dict
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--in_path', type=str, help='path to .pth file/.pth.tar file')
@@ -72,28 +73,11 @@ def model_arch_conversion(arch_string, out_path):
     model_arch_list = []
 
     for module in enumerate(model_arch.modules()):
-        if isinstance(module, nn.Conv2d):
-            model_arch_list.append({
-                        'name': module.__class__.__name__,
-                        'in_channels': module.in_channels,
-                        'out_channels': module.out_channels,
-                        'kernel_size': module.kernel_size,
-                        'stride': module.stride,
-                        'padding': module.padding,
-                    })
-        elif isinstance(module, nn.BatchNorm2d):
-            model_arch_list.append({
-                        'name': module.__class__.__name__
-                    })
-        elif isinstance(module, nn.Linear):
-            model_arch_list.append({
-                        'name': module.__class__.__name__,
-                        'in_features': module.in_features,
-                        'out_features': module.out_features,
-                        'bias': module.bias,
-                    })
-        else:
+        module_dict = module_to_dict(module)
+        if module_dict is None:
             return NotImplementedError('A module within your model is not supported.')
+
+        model_arch_list.append(module_dict)
 
     model_arch_dict = {
             'name': model_arch.__class__.__name__,
@@ -105,8 +89,3 @@ def model_arch_conversion(arch_string, out_path):
         json.dump(model_arch_dict, f)
 
 model_arch_conversion(arch, out_path)
-
-
-
-
-


### PR DESCRIPTION
- Move converter from PyTorch module to dict into `module_to_dict` function as not to clutter `weight_convert.py`
- Add support for exporting a number of [PyTorch module](https://pytorch.org/docs/stable/nn.html) types from `torch.nn` to dictionary (focused on support for vision models)